### PR TITLE
feat: Add google-sign-in pub and categoryHome_page

### DIFF
--- a/lib/Category/category_page.dart
+++ b/lib/Category/category_page.dart
@@ -2,27 +2,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'dart:ui';
 
-class CategoryPage extends StatefulWidget {
-  const CategoryPage({Key? key}) : super(key: key);
+class CategoryHomePage extends StatefulWidget {
+  const CategoryHomePage({Key? key}) : super(key: key);
 
   @override
-  _CategoryPageState createState() => _CategoryPageState();
+  _CategoryHomePageState createState() => _CategoryHomePageState();
 }
 
-class _CategoryPageState extends State<CategoryPage> {
+class _CategoryHomePageState extends State<CategoryHomePage> {
   @override
   Widget build(BuildContext context) {
     return ScreenUtilInit(
-      designSize: Size(411.4, 683.4),
-      builder: () {
-        return Scaffold(
-          appBar: AppBar(
-            title: Text(
-              "Appbar",
-              style: TextStyle(fontFamily: "Barun"),),
-          ),
-        );
-      }
+        designSize: Size(411.4, 683.4),
+        builder: () {
+          return Scaffold(
+            appBar: AppBar(
+              title: Text(
+                  "Appbar"
+              ),
+            ),
+          );
+        }
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
-      home: CategoryPage(),
+      home: CategoryHomePage(),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -86,6 +86,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.4"
+  google_sign_in:
+    dependency: "direct main"
+    description:
+      name: google_sign_in
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.4"
+  google_sign_in_platform_interface:
+    dependency: transitive
+    description:
+      name: google_sign_in_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  google_sign_in_web:
+    dependency: transitive
+    description:
+      name: google_sign_in_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.0"
   hexcolor:
     dependency: "direct main"
     description:
@@ -121,6 +142,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ environment:
 dependencies:
   flutter_screenutil: ^5.0.0+2
   get: ^4.1.4
+  google_sign_in: ^5.0.4
   hexcolor: ^2.0.4
   flutter:
     sdk: flutter


### PR DESCRIPTION
We decided to log-in with a Google account. (Token Type)
The categoryHome_page is required because the categoty_page uses expasion
tile.